### PR TITLE
Create meeting issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/meeting.yml
+++ b/.github/ISSUE_TEMPLATE/meeting.yml
@@ -1,0 +1,48 @@
+name: 📝 회의록
+description: 팀 회의 기록
+labels: ["📝 meeting"]
+body:
+  - type: dropdown
+    id: team
+    attributes:
+      label: 팀
+      options:
+        - kim-minsoo (김민수)
+    validations:
+      required: true
+  - type: input
+    id: datetime
+    attributes:
+      label: 일시
+      placeholder: "YYYY-MM-DD HH:MM ~ HH:MM"
+    validations:
+      required: true
+  - type: input
+    id: attendees
+    attributes:
+      label: 참석자
+      placeholder: "이름1, 이름2, 이름3"
+    validations:
+      required: true
+  - type: textarea
+    id: agenda
+    attributes:
+      label: 안건 및 논의 내용
+      placeholder: |
+        ### 안건 1: [제목]
+        - 논의 내용
+
+        ### 안건 2: [제목]
+        - 논의 내용
+    validations:
+      required: true
+  - type: textarea
+    id: decisions
+    attributes:
+      label: 결정 사항
+      placeholder: "- 결정 1\n- 결정 2"
+  - type: textarea
+    id: action_items
+    attributes:
+      label: Action Items
+      placeholder: "- [ ] 이름: 할 일 (마감: MM/DD)"


### PR DESCRIPTION
Add a new issue template for meeting notes with fields for team, datetime, attendees, agenda, decisions, and action items.

<!-- PR 제목 규칙: [Type] 간결한 요약 (예: [feat] ArgoCD Application 리소스 추가) -->

## 📌 변경 내용
<!-- 무엇을 왜 바꿨는지 3-5줄로 -->


## 🔗 관련 이슈
<!-- GitHub가 자동으로 이슈를 닫도록 반드시 키워드 사용 -->
Closes #


## 🧪 테스트 방법
<!-- 리뷰어가 로컬에서 확인할 수 있는 절차 -->
1.
2.
3.


## 📸 스크린샷 / 로그 (해당 시)



## ✅ 셀프 체크리스트
- [ ] 로컬에서 빌드/실행 성공
- [ ] 테스트 추가 또는 기존 테스트 통과
- [ ] 관련 문서/README/Wiki 업데이트
- [ ] `.env`·키·비밀번호 등 민감정보 커밋 없음
- [ ] 이슈 번호 연결 (`Closes #`)
- [ ] 적절한 라벨 부여

## 👀 리뷰 포인트
<!-- 리뷰어가 중점적으로 봐줬으면 하는 부분 -->

