### PR TITLE
docs: refresh public README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,47 @@
-# law_main_road (아직 초안 문서입니다. 이 저장소는 프로젝트 마무리 후 결과 코드 및 문서만을 다룹니다. 개발과정은 저희 팀의 organization에서 확인하실 수 있습니다. 마무리 문서 작업 후 팀 organization을 공개하도록 하겠습니다.)
+# 법대로(LawMainRoad)
 
-외국인 근로자를 포함한 취약 노동자를 위한 노동권 보호 AI MVP입니다.
+법대로(LawMainRoad)는 외국인 근로자와 취약 노동자가 근로계약, 임금체불,
+부당해고, 사업장 변경 같은 노동 문제를 한국 노동법 근거와 함께 정리할 수
+있도록 돕는 AI 지원 MVP입니다.
 
-현재 저장소는 법령 RAG, grounded answer generation, SCN-004 문서 초안,
-SCN-001 Firebase Auth 기반 Before/Bridge/After 연결, 기록 조회/삭제 UI까지
-구현한 상태입니다.
+이 public repository는 공모전 제출과 공개 검토를 위한 curated public mirror입니다.
+현재 public mirror는 deploy authority가 아니며, 개발과 배포 자동화의 최종
+권한을 의미하지 않습니다.
 
-## Current Status
+## 공개 문서
 
-기준일: `2026-05-04`
+상세 문서는 GitHub Wiki를 canonical 공개 문서로 사용합니다. 이 README는 첫
+화면에서 프로젝트 목적, 현재 구현 범위, 공개 경계, 실행 방법을 빠르게 확인하기
+위한 요약 문서입니다.
 
-- law corpus: `backend/data/law_chunks/all_chunks.json`
-- selected snapshot: `selected_as_of = 2026-04-11`
-- live chunks: `1722`
-- backend: FastAPI + PostgreSQL + pgvector
-- frontend: Next.js `16.2.4`, React `19.2.5`
-- auth: Firebase Auth Google Sign-In + backend Firebase Admin verification
-- answer model default: `gemini-2.5-flash`
-- embedding model default: `gemini-embedding-001`, `768` dimensions
-- latest main checkpoint: `e79fa68`
+주요 Wiki 링크:
 
-Implemented user routes:
+- [GitHub Wiki](https://github.com/Team-msp-architect-2026/msp-team02/wiki)
+- [Final-Architecture](https://github.com/Team-msp-architect-2026/msp-team02/wiki/Final-Architecture)
+- [User-Flows](https://github.com/Team-msp-architect-2026/msp-team02/wiki/User-Flows)
+- [API-Endpoints-and-Schemas](https://github.com/Team-msp-architect-2026/msp-team02/wiki/API-Endpoints-and-Schemas)
+- [Cloud-Migration-and-Public-Mirror-Policy](https://github.com/Team-msp-architect-2026/msp-team02/wiki/Cloud-Migration-and-Public-Mirror-Policy)
+
+내부 planning, architecture, operations 기록은 공개 Wiki와 README에 그대로
+노출하지 않습니다. 공개 문서는 현재 구현 기준과 공개 가능한 범위를 기준으로
+다시 정리한 내용입니다.
+
+## 현재 구현 범위
+
+기준일: `2026-05-07`
+
+- SCN-004 login-free After answer/draft demo
+- SCN-001 Before -> Bridge -> After answer linkage
+- SCN-001 protected history archive and MVP soft-delete
+- SCN-001 고정 preset 기반 frontend-local frozen draft demo
+- Firebase Auth Google Sign-In + backend verification
+- PostgreSQL + pgvector 기반 법령 검색
+- Vertex AI Gemini 기반 answer/OCR/embedding 연동
+- Next.js App Router 기반 frontend
+- FastAPI 기반 backend
+- 법령 chunk `1722`개, `selected_as_of = 2026-04-11`
+
+구현된 주요 route:
 
 - `/`
 - `/before`
@@ -30,69 +51,114 @@ Implemented user routes:
 - `/after/draft`
 - `/history`
 
-Main implemented flows:
+대표 흐름:
 
-- SCN-004 login-free After flow:
-  `/after -> /after/result -> /after/intake -> /after/draft`
-- SCN-001 protected Before/Bridge/After answer linkage
-- SCN-001 protected history archive and MVP soft-delete
-- SCN-001 exact fixed-preset frontend-local frozen draft flow
-- SCN-004 exact fixed-preset answer fixture for stable demo rehearsal
-- integrated frontend UI polish through visual checkpoint `85d10fa`, with
-  later workspace/draft-scope documentation alignment through `e79fa68`:
-  - Before first screen is upload-focused, removes local server/demo copy,
-    preserves examples, improves loading scroll and OCR 1~2분 guidance, cleans
-    result/accessibility layout, and removes hardcoded default accessibility
-    legal basis
-  - After entry is centered, adds guidance cards, improves preset display labels
-    without changing preset id/query, restores the entry disclaimer, and uses
-    primary-blue / success-green saved-history connection accents
-  - History is centered with readable folded incident cards and blue left accent
-  - Main page has cleaner H1/lead/nav typography and a compact flow strip
-  - `DESIGN.md` is the current visual guide: token-first,
-    neutral/dense/evidence-led, with disclaimers and uncertainty prominent
+- SCN-004: `/after -> /after/result -> /after/intake -> /after/draft`
+- SCN-001: Before review -> Bridge context -> After answer
+- History: backend-verified user의 SCN-001 record archive와 MVP soft-delete
 
-Not opened:
+## 아키텍처 요약
 
-- live/backend SCN-001 document draft generation
-- protected SCN-001 draft endpoint
-- independent `/bridge` route
-- Recovery implementation
-- SCN-005 frontend/document draft expansion
-- Step 3 full retention lifecycle
-- public contract changes for `/api/v1/answer` or `/api/v1/documents/draft`
+```text
+legal source data
+  -> preprocessing / chunking
+  -> law chunks
+  -> PostgreSQL + pgvector
+  -> retrieval
+  -> grounded answer
+  -> optional document draft
+  -> Next.js frontend
+```
 
-## GitHub Docs
+주요 기술:
 
-Readable GitHub-facing docs are separated from internal planning notes:
-
-- [docs/github/README.md](docs/github/README.md)
-- [docs/github/project-overview.md](docs/github/project-overview.md)
-- [docs/github/system-architecture.md](docs/github/system-architecture.md)
-- [docs/github/user-flows.md](docs/github/user-flows.md)
-- [docs/github/api-reference.md](docs/github/api-reference.md)
-- [docs/github/runbook.md](docs/github/runbook.md)
-
-Internal phase records remain under `docs/planning/`. The current code-based
-checkpoint is
-[docs/planning/23_code_based_status_2026_04_29.md](docs/planning/23_code_based_status_2026_04_29.md).
-
-## Repository Layout
-
-| Path | Role |
+| 영역 | 기술 |
 |---|---|
-| `backend/` | FastAPI app, retrieval, answer generation, document draft, auth, DB |
-| `frontend/` | Next.js app routes and UI state |
-| `scripts/` | legal corpus preprocessing pipeline |
-| `data/legalize-kr/` | upstream law source submodule |
-| `backend/data/law_chunks/` | processed law chunk output |
-| `docs/planning/` | internal phase/status planning notes |
-| `docs/github/` | public-facing GitHub documentation |
-| `docs/product/` | product flow notes |
-| `docs/ops/` | local setup and operations notes |
-| `eval/` | retrieval/answer eval assets |
+| Frontend | Next.js App Router, React, TypeScript |
+| Backend | FastAPI |
+| Database | PostgreSQL + pgvector |
+| Auth | Firebase Auth Google Sign-In, Firebase Admin verification |
+| LLM/OCR | Vertex AI Gemini |
+| Embedding | `gemini-embedding-001`, 768 dimensions |
 
-## Quick Start
+## API와 사용자 흐름
+
+공개 문서의 canonical API 설명은
+[API-Endpoints-and-Schemas](https://github.com/Team-msp-architect-2026/msp-team02/wiki/API-Endpoints-and-Schemas)를
+따릅니다.
+
+현재 README에서 강조하는 public/protected API 경계:
+
+- `/api/v1/retrieve`
+- `/api/v1/answer`
+- `/api/v1/documents/draft`
+- `/api/v1/auth/me`
+- `/api/v1/scn001/bridge-runs`
+- `/api/v1/scn001/before-review-jobs`
+
+SCN-004 After flow는 login-free demo 흐름을 유지합니다. SCN-001 protected
+actions는 backend-verified auth를 요구합니다. Bridge는 사건 맥락을 이어 주는
+연결/참고 정보이며, 법적 근거(legal grounding)가 아닙니다.
+
+## 데모 / 클라우드 상태
+
+Cloud migration은 dev-first policy를 사용합니다.
+
+- `dev`: first cloud target and smoke-test environment
+- `demo/contest`: dev smoke 이후 기간 한정 public presentation posture
+- `prod`: 별도 production-opening review 전까지 미오픈(NOT opened)
+
+이 저장소와 공개 문서는 운영 배포 주장으로 읽히지 않습니다. 공모전 제출과 공개
+검토를 위한 demo posture, 구현 범위, 미오픈 범위를 구분해 설명합니다.
+
+public mirror는 curated submission surface이며 deploy authority가 아닙니다.
+cloud migration과 public mirror 정책의 상세 내용은
+[Cloud-Migration-and-Public-Mirror-Policy](https://github.com/Team-msp-architect-2026/msp-team02/wiki/Cloud-Migration-and-Public-Mirror-Policy)를
+따릅니다.
+
+## 미오픈 범위
+
+다음 항목은 현재 공개 구현 범위에서 미오픈(NOT opened) 상태입니다.
+
+- SCN-001 live/backend document draft generation
+- protected SCN-001 draft endpoint
+- independent `/bridge`
+- Recovery
+- SCN-005
+- full retention lifecycle
+- hard delete, artifact purge, account deletion, undo/restore
+- 운영 배포 주장
+
+SCN-001의 고정 preset 기반 frozen draft demo는 frontend-local deterministic
+flow입니다. live/backend SCN-001 draft generation 또는 protected SCN-001 draft
+endpoint를 의미하지 않습니다.
+
+## 보안과 개인정보 경계
+
+공개 문서와 public mirror에는 다음 정보를 포함하지 않습니다.
+
+- 인증 비밀값, local env values, cloud secret values
+- infrastructure state files 또는 cloud IAM key files
+- cloud project identifier, runtime URL, private cloud inventory
+- 인증 provider의 개인 식별자, 이메일 값, database account identifier
+- 사건 원문 데이터, 답변/초안/Bridge 전체 원문 데이터
+- 승인된 public mirror 정책을 넘어서는 private development/deploy 세부 정보
+
+Frontend는 민감한 flow 원문 데이터를 Web Storage에 저장하지 않는 방향으로 설계되어
+있습니다. SCN-001 protected actions는 backend verification 이후에만 수행됩니다.
+
+## 개발 과정 및 commit 기록 안내
+
+개발 과정과 commit 기록은 현재 private organization에서 관리 중이며, 공개 전환
+이후 아래 organization에서 확인할 수 있도록 연결할 예정입니다.
+
+- https://github.com/2026-moel-datacontest-core
+
+이 README에는 private repository 이름, cloud project identifier, runtime URL,
+credential, deployment identity, infrastructure state, secret value를 공개하지
+않습니다.
+
+## 로컬 실행
 
 Backend:
 
@@ -110,7 +176,7 @@ npm install
 npm run dev
 ```
 
-Default URLs:
+Default local URLs:
 
 - backend: `http://localhost:8000`
 - frontend: `http://localhost:5090`
@@ -120,7 +186,7 @@ Environment templates:
 - [backend/.env.example](backend/.env.example)
 - [frontend/.env.example](frontend/.env.example)
 
-## Verification
+## 검증
 
 Focused checks:
 
@@ -137,14 +203,11 @@ Demo preflight:
 bash scripts/demo_preflight.sh
 ```
 
-Run broad retrieval/answer eval only when retrieval, answer generation,
-embedding behavior, DB contents, or API response contracts change.
+Broad retrieval/answer eval은 retrieval, answer generation, embedding behavior,
+DB contents, API response contract가 변경된 경우에만 별도로 수행합니다.
 
-## Privacy Boundaries
+## 참고
 
-- Do not commit credential JSON, local env files, DB files, Firebase ID tokens,
-  provider subjects, or raw email values.
-- Raw `user_statement`, full answer/draft payloads, case intake, raw Bridge
-  payloads, and raw `after_query_seed` are not stored in browser storage.
-- SCN-001 Bridge context is continuity/reference only, not legal grounding.
-- `data/legalize-kr/` and `backend/data/law_chunks/` are not edited directly.
+법대로(LawMainRoad)는 법률 정보를 정리하고 관련 근거를 확인하는 데 도움을 주는
+MVP입니다. 결과는 법률 자문이나 행정기관의 판단을 대체하지 않으며, 실제 신고,
+상담, 소송, 체류 관련 결정에는 관련 기관 또는 전문가 확인이 필요합니다.


### PR DESCRIPTION
Summary
- Replace the draft README with a public-facing LawMainRoad overview.
- Link the published GitHub Wiki as the canonical detailed documentation.
- Clarify current scope, NOT opened areas, demo/cloud posture, privacy boundaries, and future development-history organization link.

Verification
- git diff --check -- README.md passed.
- Sensitive/internal term scan passed for README.md.
- Changed file scope is README.md only.

Notes
- Wiki pages were already published separately to the GitHub Wiki repository.
- Main is protected, so this README update requires code owner approval before merge.