### PR TITLE
docs: use youtube demo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,10 @@
 ![법대로 메인 화면](docs/images/home-hero.png)
 
 - **공개 데모:** https://www.law-main-road.cloud
-- **데모 미리보기:** 아래 GIF에서 전체 흐름을 바로 볼 수 있습니다.
-- **MP4 파일:** [브라우저에서 열기 또는 다운로드](https://raw.githubusercontent.com/Team-msp-architect-2026/msp-team02/main/docs/video/lmr_demo_web.mp4)
+- **데모 시연 영상:** [YouTube에서 보기](https://youtu.be/fFEPP3KtHMs)
+- **MP4 백업 파일:** [브라우저에서 열기 또는 다운로드](https://raw.githubusercontent.com/Team-msp-architect-2026/msp-team02/main/docs/video/lmr_demo_web.mp4)
 
-![법대로 데모 영상 미리보기](docs/video/lmr_demo_preview.gif)
+[![법대로 데모 시연 영상](https://img.youtube.com/vi/fFEPP3KtHMs/maxresdefault.jpg)](https://youtu.be/fFEPP3KtHMs)
 
 이 MVP는 법률 정보를 정리하고 관련 근거를 확인하는 데 도움을 주는 도구입니다.
 변호사 자문, 행정기관 판단, 법원의 판단을 대체하지 않습니다.
@@ -25,7 +25,7 @@
 
 5분 안에 확인할 수 있는 흐름입니다.
 
-1. 위 데모 미리보기 GIF로 전체 흐름을 먼저 확인합니다.
+1. 위 YouTube 썸네일을 클릭해 전체 시연 영상을 먼저 확인합니다.
 2. https://www.law-main-road.cloud 를 엽니다.
 3. 메인 화면에서 AI 법률 상담을 선택합니다.
 4. 예시 사례에서 `임금체불·부당해고 상담`을 선택하고 제출합니다.
@@ -72,7 +72,7 @@
 - PostgreSQL + pgvector 기반 법령 검색
 - Vertex AI Gemini 기반 답변, OCR, 임베딩 연동
 - 공개 데모 도메인 `https://www.law-main-road.cloud` 연결
-- 공개 검토용 데모 미리보기 GIF와 MP4 파일
+- 공개 검토용 YouTube 시연 영상과 MP4 백업 파일
 - Next.js 화면과 FastAPI 서버 기반 구현
 - 2026년 4월 11일 기준으로 정리한 법령 조각 1,722개 사용
 
@@ -149,8 +149,8 @@ API의 상세 경로와 요청/응답 구조는
 
 - 백엔드와 프론트엔드 기본 동작 확인 완료
 - 공개 데모 도메인 연결 완료: `https://www.law-main-road.cloud`
-- 공개 검토용 데모 미리보기 GIF 배치: `docs/video/lmr_demo_preview.gif`
-- 공개 검토용 web-optimized MP4 파일 배치: `docs/video/lmr_demo_web.mp4`
+- 공개 검토용 YouTube 시연 영상 연결: `https://youtu.be/fFEPP3KtHMs`
+- 공개 검토용 web-optimized MP4 백업 파일 배치: `docs/video/lmr_demo_web.mp4`
 - Google 로그인 허용 도메인과 서버 CORS 설정은 `www` 도메인 기준으로 확인
 - 사용자가 접속하는 프론트엔드 URL만 공개하고, 서버 직접 실행 URL과 내부 클라우드 목록은 공개하지 않음
 

--- a/docs/video/README.md
+++ b/docs/video/README.md
@@ -4,15 +4,21 @@
 
 ## 공개 문서 연결 대상
 
-- `lmr_demo_preview.gif`
 - `lmr_demo_web.mp4`
 
-`lmr_demo_preview.gif`는 GitHub README와 Wiki에서 바로 보이도록 만든 2분 전체 흐름
-미리보기입니다.
+README와 Wiki의 대표 영상 링크는 YouTube 시연 영상입니다.
 
-`lmr_demo_web.mp4`는 web-optimized MP4 파일입니다. GitHub의 repo file viewer는
+```text
+https://youtu.be/fFEPP3KtHMs
+```
+
+GitHub README/Wiki는 YouTube iframe player를 허용하지 않으므로, 공개 문서에서는
+YouTube thumbnail image를 크게 보여 주고 클릭 시 YouTube 영상으로 이동하도록
+연결합니다.
+
+`lmr_demo_web.mp4`는 web-optimized MP4 백업 파일입니다. GitHub의 repo file viewer는
 MP4를 바로 재생하지 않고 다운로드 화면을 보일 수 있으므로, 공개 문서의 첫 확인
-자료는 GIF를 기준으로 안내합니다.
+자료는 YouTube 링크를 기준으로 안내합니다.
 
 ## 로컬 원본
 


### PR DESCRIPTION
## Summary
- replace the choppy GIF preview with a YouTube thumbnail link
- clarify that GitHub README/Wiki cannot embed a YouTube iframe player
- keep the MP4 as a backup open/download file

## Verification
- markdown whitespace check passed
- README/wiki link check passed from staging source
- YouTube and thumbnail URLs return 200/redirect successfully